### PR TITLE
Fail silently

### DIFF
--- a/lib/telegrammer.rb
+++ b/lib/telegrammer.rb
@@ -56,5 +56,12 @@ module Telegrammer
         super("Telegram API Service unavailable (HTTP error code #{status_code})")
       end
     end
+
+    # Error returned when HTTPClient raise a timeout (?)
+    class TimeoutError < StandardError
+      def initialize(message)
+        super("Timeout reached. Message: #{message}")
+      end
+    end
   end
 end

--- a/lib/telegrammer/api_response.rb
+++ b/lib/telegrammer/api_response.rb
@@ -4,7 +4,7 @@ module Telegrammer
     attr_reader :result
     attr_reader :success
 
-    def initialize(response)
+    def initialize(response,fail_silently = false)
       if response.status < 500
         @body = response.body
 
@@ -14,10 +14,14 @@ module Telegrammer
         if @success
           @result = data['result']
         else
-          fail Telegrammer::Errors::BadRequestError, data['error_code'], data['description']
+          if !fail_silently
+            fail Telegrammer::Errors::BadRequestError, data['error_code'], data['description']
+          end
         end
       else
-        fail Telegrammer::Errors::ServiceUnavailableError, response.status
+        if !fail_silently
+          fail Telegrammer::Errors::ServiceUnavailableError, response.status
+        end
       end
     end
 

--- a/lib/telegrammer/bot.rb
+++ b/lib/telegrammer/bot.rb
@@ -26,6 +26,11 @@ module Telegrammer
 
     # Get incoming updates using long polling
     #
+    # @param [Hash] opts Options when getting updates
+    # @option params [Integer] :fail_silently Optional. Ignore every Connection Error. Default: false
+    # @option params [Integer] :offset Optional. Sequential number of the first photo to be returned. By default, all photos are returned.
+    # @option params [Integer] :timeout Optional. Timeout in minutes. 0 for short polling, Default: 60.
+    #
     # @example
     #     bot = Telegrammer::Bot.new('[YOUR TELEGRAM TOKEN]')
     #
@@ -37,8 +42,17 @@ module Telegrammer
     #       # To learn more about commands, see https://core.telegram.org/bots#commands
     #     end
     #
+    #     bot.get_updates({fail_silently:true, timeout:20}) do |message|
+    #       puts "In chat #{message.chat.id}, @#{message.from.username} said: #{message.text}"
+    #       bot.send_message(chat_id: message.chat.id, text: "You said: #{message.text}")
+    #
+    #       # Here you can also process message text to detect user commands
+    #       # To learn more about commands, see https://core.telegram.org/bots#commands
+    #     end
+    #
     # @raise [Telegrammer::Errors::BadRequestError] if something goes wrong in the Telegram API servers with the params received by the operation
     # @raise [Telegrammer::Errors::ServiceUnavailableError] if Telegram servers are down
+    # @raise [Telegrammer::Errors::TimeoutError] if HTTPClient connection goes timeout
     def get_updates(opts={}, &_block)
       loop do
       	if opts[:fail_silently]

--- a/lib/telegrammer/bot.rb
+++ b/lib/telegrammer/bot.rb
@@ -44,7 +44,7 @@ module Telegrammer
       	if opts[:fail_silently]
       		@fail_silently = true
       	end
-        response = api_request('getUpdates', { offset: @offset, timeout: @timeout }, nil)
+        response = api_request('getUpdates', { offset: opts[:offset] || @offset, timeout: opts[:timeout] || @timeout }, nil)
 
         response.result.each do |raw_update|
           update = Telegrammer::DataTypes::Update.new(raw_update)


### PR DESCRIPTION
Like #9 
- Implemented fail_silently (no **Connection** Error/Exception when `true`,  **_default: false**_)
- Rescue HTTPClient::ReceiveTimeoutError and raised under the new Telegrammer::Errors::TimeoutError
- Can set custom timeout and offset

Enable fail_silently like this:

``` ruby
bot.get_updates(fail_silently: true) do |message|
  #code
end
```

Or fail_silently, offset and timeout like this:

``` ruby
bot.get_updates({fail_silently: true, offset: 0, timeout: 20}) do |message|
  #code
end
```

Remember to set your Gemfile like this:
`gem "telegrammer", ">= 0.4.2"`
(**note** 0.4.2 still need to be released)
